### PR TITLE
Fix internal module imports for MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Add the repository root to PYTHONPATH so `import src.*` works in tests
+      PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -18,7 +21,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests
-        env:
-          PYTHONPATH: src
         run: |
-          pytest
+          pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pc-reviewer"
+version = "0.0.0"
+description = "pc-reviewer"
+readme = "README.md"
+authors = [ { name = "estbndlt" } ]
+license = { text = "MIT" }
+dependencies = []
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""pc-reviewer package."""

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -8,11 +8,11 @@ from datetime import datetime, UTC
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import PlainTextResponse
 
-from tools.fs_tools import du_k, bigfiles
-from tools.pkg_tools import pkg_caches
-from tools.docker_tools import docker_df
-from tools.proc_tools import top_procs
-from logging_middleware import setup_logging
+from .tools.fs_tools import du_k, bigfiles
+from .tools.pkg_tools import pkg_caches
+from .tools.docker_tools import docker_df
+from .tools.proc_tools import top_procs
+from .logging_middleware import setup_logging
 
 app = FastAPI()
 setup_logging(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,0 @@
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,4 @@
-from tools.common import sh
+from src.tools.common import sh
 
 
 def test_sh_runs_command():

--- a/tests/test_docker_tools.py
+++ b/tests/test_docker_tools.py
@@ -1,4 +1,4 @@
-from tools.docker_tools import docker_df
+from src.tools.docker_tools import docker_df
 
 
 def test_docker_df_structure():

--- a/tests/test_exec_tool.py
+++ b/tests/test_exec_tool.py
@@ -1,5 +1,5 @@
 import pytest
-from tools.exec_tool import exec_run
+from src.tools.exec_tool import exec_run
 
 
 def test_exec_run_disabled():

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -1,4 +1,4 @@
-from tools.fs_tools import du_k, bigfiles
+from src.tools.fs_tools import du_k, bigfiles
 from pathlib import Path
 import tempfile
 

--- a/tests/test_logging_middleware.py
+++ b/tests/test_logging_middleware.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import logging
-from logging_middleware import setup_logging
+from src.logging_middleware import setup_logging
 
 
 app = FastAPI()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from mcp_server import app
+from src.mcp_server import app
 
 client = TestClient(app)
 

--- a/tests/test_pkg_tools.py
+++ b/tests/test_pkg_tools.py
@@ -1,4 +1,4 @@
-from tools.pkg_tools import pkg_caches
+from src.tools.pkg_tools import pkg_caches
 
 
 def test_pkg_caches_keys_and_types():

--- a/tests/test_proc_tools.py
+++ b/tests/test_proc_tools.py
@@ -1,4 +1,4 @@
-from tools.proc_tools import top_procs
+from src.tools.proc_tools import top_procs
 
 
 def test_top_procs_basic():


### PR DESCRIPTION
## Summary
- add package init so `src` is importable
- switch server to package-relative imports
- update tests to use the `src` package paths

## Testing
- `python -m pytest`
- `uvicorn src.mcp_server:app --host 0.0.0.0 --port 8765`

------
https://chatgpt.com/codex/tasks/task_e_68aa84b656c8832dad7160f9e4233e08