### PR TITLE
Ensure src is on Python path for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests
+        env:
+          PYTHONPATH: src
         run: |
           pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = src
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning


### PR DESCRIPTION
## Summary
- ensure CI test step includes src in PYTHONPATH
- configure pytest to add src to Python path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa8883634c832dbcee25caf7601ec5